### PR TITLE
Fixed the conflict between system-installed yaml-cpp 0.3 and this yaml-cpp 0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,13 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(yaml_cpp_src
   URL https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz
   UPDATE_COMMAND ""
+  PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/extra_version.patch
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DBUILD_SHARED_LIBS=ON
 )
 
 cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)
 add_dependencies(${PROJECT_NAME} yaml_cpp_src)
-target_link_libraries(${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/lib/libyaml-cpp${CMAKE_SHARED_LIBRARY_SUFFIX})
+target_link_libraries(${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/lib/libyaml-cpp0.5${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 cs_install()
 

--- a/cmake/yaml-cpp-extras.cmake.in
+++ b/cmake/yaml-cpp-extras.cmake.in
@@ -1,4 +1,4 @@
 # This overrides the dependency tracker with the yamlcpp library file.
 set(@PROJECT_NAME@_LIBRARIES 
-  @CATKIN_DEVEL_PREFIX@/lib/libyaml-cpp${CMAKE_SHARED_LIBRARY_SUFFIX})
+  @CATKIN_DEVEL_PREFIX@/lib/libyaml-cpp0.5${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(@PROJECT_NAME@_INCLUDE_DIR @CATKIN_DEVEL_PREFIX@/include)

--- a/extra_version.patch
+++ b/extra_version.patch
@@ -1,0 +1,136 @@
+From 7cc9af7909847f2335ffc9135eef6415865c2556 Mon Sep 17 00:00:00 2001
+From: Martin Pecka <peckama2@fel.cvut.cz>
+Date: Mon, 26 Sep 2016 16:07:49 +0200
+Subject: [PATCH] Added the 0.5 suffix to the shared library name.
+
+---
+ CMakeLists.txt      | 28 ++++++++++++++--------------
+ test/CMakeLists.txt |  2 +-
+ util/CMakeLists.txt |  6 +++---
+ yaml-cpp.pc.cmake   |  4 ++--
+ 4 files changed, 20 insertions(+), 20 deletions(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index d4a8e29..cfdb08e 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -269,19 +269,19 @@ set(_INSTALL_DESTINATIONS
+ ###
+ ### Library
+ ###
+-add_library(yaml-cpp ${library_sources})
+-set_target_properties(yaml-cpp PROPERTIES
++add_library(yaml-cpp0.5 ${library_sources})
++set_target_properties(yaml-cpp0.5 PROPERTIES
+   COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags}"
+ )
+ 
+-set_target_properties(yaml-cpp PROPERTIES
++set_target_properties(yaml-cpp0.5 PROPERTIES
+ 	VERSION "${YAML_CPP_VERSION}"
+ 	SOVERSION "${YAML_CPP_VERSION_MAJOR}.${YAML_CPP_VERSION_MINOR}"
+-	PROJECT_LABEL "yaml-cpp ${LABEL_SUFFIX}"
++	PROJECT_LABEL "yaml-cpp0.5 ${LABEL_SUFFIX}"
+ )
+ 
+ if(IPHONE)
+-	set_target_properties(yaml-cpp PROPERTIES
++	set_target_properties(yaml-cpp0.5 PROPERTIES
+ 		XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "3.0"
+ 	)
+ endif()
+@@ -289,7 +289,7 @@ endif()
+ if(MSVC)
+ 	if(NOT BUILD_SHARED_LIBS)
+ 		# correct library names
+-		set_target_properties(yaml-cpp PROPERTIES
++		set_target_properties(yaml-cpp0.5 PROPERTIES
+ 			DEBUG_POSTFIX "${LIB_TARGET_SUFFIX}d"
+ 			RELEASE_POSTFIX "${LIB_TARGET_SUFFIX}"
+ 			MINSIZEREL_POSTFIX "${LIB_TARGET_SUFFIX}"
+@@ -298,7 +298,7 @@ if(MSVC)
+ 	endif()
+ endif()
+ 
+-install(TARGETS yaml-cpp ${_INSTALL_DESTINATIONS})
++install(TARGETS yaml-cpp0.5 ${_INSTALL_DESTINATIONS})
+ install(
+ 	DIRECTORY ${header_directory}
+ 	DESTINATION ${INCLUDE_INSTALL_DIR}
+@@ -306,19 +306,19 @@ install(
+ )
+ 
+ export(
+-    TARGETS yaml-cpp
+-    FILE "${PROJECT_BINARY_DIR}/yaml-cpp-targets.cmake")
+-export(PACKAGE yaml-cpp)
+-set(EXPORT_TARGETS yaml-cpp CACHE INTERNAL "export targets")
++    TARGETS yaml-cpp0.5
++    FILE "${PROJECT_BINARY_DIR}/yaml-cpp0.5-targets.cmake")
++export(PACKAGE yaml-cpp0.5)
++set(EXPORT_TARGETS yaml-cpp0.5 CACHE INTERNAL "export targets")
+ 
+ set(CONFIG_INCLUDE_DIRS "${YAML_CPP_SOURCE_DIR}/include")
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp-config.cmake.in
+-	"${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake" @ONLY)
++	"${PROJECT_BINARY_DIR}/yaml-cpp0.5-config.cmake" @ONLY)
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp-config-version.cmake.in
+-	"${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake" @ONLY)
++	"${PROJECT_BINARY_DIR}/yaml-cpp0.5-config-version.cmake" @ONLY)
+ 
+ if(UNIX)
+-	set(PC_FILE ${CMAKE_BINARY_DIR}/yaml-cpp.pc)
++	set(PC_FILE ${CMAKE_BINARY_DIR}/yaml-cpp0.5.pc)
+ 	configure_file("yaml-cpp.pc.cmake" ${PC_FILE} @ONLY)
+ 	install(FILES ${PC_FILE} DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+ endif()
+diff --git test/CMakeLists.txt test/CMakeLists.txt
+index 61f1f7f..ce67c54 100644
+--- test/CMakeLists.txt
++++ test/CMakeLists.txt
+@@ -29,6 +29,6 @@ add_executable(run-tests
+ set_target_properties(run-tests PROPERTIES
+   COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
+ )
+-target_link_libraries(run-tests yaml-cpp gmock)
++target_link_libraries(run-tests yaml-cpp0.5 gmock)
+ 
+ add_test(yaml-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run-tests)
+diff --git util/CMakeLists.txt util/CMakeLists.txt
+index 8a69631..cdad385 100644
+--- util/CMakeLists.txt
++++ util/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ add_sources(parse.cpp)
+ add_executable(parse parse.cpp)
+-target_link_libraries(parse yaml-cpp)
++target_link_libraries(parse yaml-cpp0.5)
+ 
+ add_sources(sandbox.cpp)
+ add_executable(sandbox sandbox.cpp)
+-target_link_libraries(sandbox yaml-cpp)
++target_link_libraries(sandbox yaml-cpp0.5)
+ 
+ add_sources(read.cpp)
+ add_executable(read read.cpp)
+-target_link_libraries(read yaml-cpp)
++target_link_libraries(read yaml-cpp0.5)
+diff --git yaml-cpp.pc.cmake yaml-cpp.pc.cmake
+index 04d343f..48c8006 100644
+--- yaml-cpp.pc.cmake
++++ yaml-cpp.pc.cmake
+@@ -3,9 +3,9 @@ exec_prefix=@CMAKE_INSTALL_PREFIX@
+ libdir=${prefix}/@LIB_INSTALL_DIR@
+ includedir=${prefix}/@INCLUDE_INSTALL_ROOT_DIR@
+ 
+-Name: Yaml-cpp
++Name: Yaml-cpp0.5
+ Description: A YAML parser and emitter for C++
+ Version: @YAML_CPP_VERSION@
+ Requires:
+-Libs: -L${libdir} -lyaml-cpp
++Libs: -L${libdir} -lyaml-cpp0.5
+ Cflags: -I${includedir}
+-- 
+2.9.3
+


### PR DESCRIPTION
This fixes the issue where (for example) rviz on indigo depends on yaml-cpp 0.3, and some other package uses yaml_cpp_catkin to get yaml-cpp 0.5. Both of these libraries have the same name of the shared object file, `libyaml-cpp.so`, so only one version of yaml-cpp can be in the system at one time. An example of the problem caused to rviz can be seen here: https://github.com/ros-visualization/rviz/issues/1000 .

This PR renames the shared object file to `libyaml-cpp0.5.so`, which is no longer conflicting with the older one.

I'd bet just using a different library name should not break existing code, if it depends just on `yaml_cpp_catkin` (or `YAML_CPP_CATKIN_EXPORTED_TARGETS`) and not directly on `yaml-cpp` target. In the latter case, all `target_link_libraries(... yaml-cpp)` need to be rewritten to `target_link_libraries(... yaml-cpp0.5)`.

All projects depending on this package need to be rebuilt, and especially the devel directory to be deleted (or at least devel/lib/libyaml-cpp.so\* ). Maybe also build/yaml_cpp_catkin (not sure about this one).

@rdube and @gawela might be interested in testing if it doesn't break their code.

I'm not quite sure if this is the right way to go, but I think it definitely needs to be solved in some way, so that this package doesn't break rviz.
