### PR TITLE
Catkin install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 *.exe
 *.out
 *.app
+
+# Bloom.
+debian
+obj*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(yaml_cpp_src
   GIT_REPOSITORY  https://github.com/jbeder/yaml-cpp
   GIT_TAG ${YAML_CPP_TAG}
+  UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/extra_version.patch
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DBUILD_SHARED_LIBS=ON
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,11 @@ ExternalProject_Add(yaml_cpp_src
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DBUILD_SHARED_LIBS=ON
 )
 
-cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)
-add_dependencies(${PROJECT_NAME} yaml_cpp_src)
-target_link_libraries(${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/lib/libyaml-cpp0.5${CMAKE_SHARED_LIBRARY_SUFFIX})
-
-cs_install()
-
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/yaml-cpp
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
+        DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        FILES_MATCHING PATTERN "libyaml-cpp*")
 cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
-  CFG_EXTRAS yaml-cpp-extras.cmake)
+          LIBRARIES yaml-cpp0.5)

--- a/cmake/yaml-cpp-extras.cmake.in
+++ b/cmake/yaml-cpp-extras.cmake.in
@@ -1,4 +1,0 @@
-# This overrides the dependency tracker with the yamlcpp library file.
-set(@PROJECT_NAME@_LIBRARIES 
-  @CATKIN_DEVEL_PREFIX@/lib/libyaml-cpp0.5${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(@PROJECT_NAME@_INCLUDE_DIR @CATKIN_DEVEL_PREFIX@/include)

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>yaml_cpp_catkin</name>
-  <version>0.0.0</version>
+  <version>0.5.90</version>
   <description>yaml_cpp_catkin</description>
   <maintainer email="slynen@ethz.ch">Simon Lynen</maintainer>
 


### PR DESCRIPTION
Status here: this is working, but it also install some extra stuff when creating a debian package out of it:
- Generated debian package contains headers and libs twice:
  - In `/home/<user>/<catkin_ws>/src/maplab_dependencies/3rdparty/yaml_cpp_catkin/obj-x86_64-linux-gnu/devel`
  - And in `/opt/ros/kinetic`
- Output of `fakeroot debian/…` shows two install steps:
```
Install the project…
-- Install configuration: "Release"
-- Installing:
/home/eggerk/install_ws/src/maplab_dependencies/3rdparty/yaml_cpp_catkin/debian/ros-kinetic-yaml-cpp-catkin/home/eggerk/install_ws/src/maplab_dependencies/3rdparty/yaml_cpp_catkin/obj-x86_64-linux-gnu/devel/lib/libyaml-cpp0.5.so.0.5.3
...
Install the project…
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "None"
-- Installing: /home/eggerk/install_ws/src/maplab_dependencies/3rdparty/yaml_cpp_catkin/debian/ros-kinetic-yaml-cpp-catkin/opt/ros/kinetic/include/yaml-cpp
...
```
- Compared output of same command for `glog_catkin`:
```
Install the project…
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "None"
-- Installing: /home/eggerk/install_ws/src/maplab_dependencies/3rdparty/glog_catkin/debian/ros-kinetic-glog-catkin/opt/ros/kinetic/include/glog
...
```
  (Installing of the project is only done once.)
